### PR TITLE
Fetch the branch in the github flow, just like we do in phabricator.

### DIFF
--- a/bin/revisionid-to-diffid.sh
+++ b/bin/revisionid-to-diffid.sh
@@ -72,6 +72,9 @@ resolve_github() {
     # Don't bother with jq -- it's another dep, and this is easy enough
     # to parse manually.
     branch=`echo "$json" | sed -ne 's/.*"headRefName": *"\([^"]*\)".*/\1/p'`
+    # Make sure the branch exists locally, too.
+    git fetch origin "$branch" >&2 \
+        || echo "WARNING: unable to fetch '$branch'; perhaps it was never pushed?" >&2
     echo "$branch"
 }
 


### PR DESCRIPTION
## Summary:
Otherwise, if you try to `git checkout` the branch, you won't be able
to because the local setup doesn't know about the branch.

Issue: https://khanacademy.slack.com/archives/C013ANU53LK/p1638383927149500

## Test plan:
I ran
    git co 2530
and it succeeded even though I had never used `fei-4164` before.