### PR TITLE
[🔥AUDIT🔥] Use raw-strings for `re.compile`.

### DIFF
--- a/bin/git-find-reviewers
+++ b/bin/git-find-reviewers
@@ -26,9 +26,9 @@ import subprocess
 #    @@ -<startline>,<numlines> ...
 # or @@ -<startline> ...               # in which <numlines> is taken to be 1
 # (Everything else is header or diff content, which we ignore.)
-_DIFFLINE_RE = re.compile('^@@ -(\d+)(?:,(\d+))? ')
+_DIFFLINE_RE = re.compile(r'^@@ -(\d+)(?:,(\d+))? ')
 
-_NEWFILE_RE = re.compile('^--- (.*)')
+_NEWFILE_RE = re.compile(r'^--- (.*)')
 
 
 class Mercurial(object):


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
I updated to a new python and got this warning when running
`git findreviewers`:
```
/home/csilvers/khan/devtools/git-workflow/bin/git-find-reviewers:29: SyntaxWarning: invalid escape sequence '\d'
  _DIFFLINE_RE = re.compile('^@@ -(\d+)(?:,(\d+))? ')
```

Issue: none

## Test plan:
I ran `git findreviewers -r HEAD^` with success.