### PR TITLE
Add deprecation warnings to these scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ at Khan Academy. (see also: [arcanist])
 [git-at-ka]: https://khanacademy.org/r/git-at-ka
 [arcanist]:  https://github.com/khan/arcanist
 
+> ### NOTE: As of Spring 2025, the scripts in _*this*_ repository are no longer in use at Khan Academy. They have been combined with Our Lovely CLI, so please make any future changes in that repo. This repo is preserved here for historical purposes.
 
 #### git deploy-branch
 Creates a remote _deploy branch_ for use with GitHub-style deploys.

--- a/bin/git-deploy-branch
+++ b/bin/git-deploy-branch
@@ -1,5 +1,9 @@
 #!/bin/sh -e
 
+echo "\n\033[1;31m⚠️  DEPRECATION WARNING:\033[0;31m This version of \
+git-deploy-branch has been deprecated."
+echo "It is now being maintained in Khan Academy's OLC repo.\033[0m\n"
+
 USAGE=`cat<<EOF
 USAGE: git deploy-branch <branchname> [parent -- defaults to origin/master]
 

--- a/bin/git-find-reviewers
+++ b/bin/git-find-reviewers
@@ -258,6 +258,18 @@ cmdtable = {
      '[-f] [-n #] [-w] [-i <commit_id> ...] [FILE...]')
     }
 
+def print_deprecation_warning():
+    RED = "\033[0;31m"
+    BOLD_RED = "\033[1;31m"
+    RESET = "\033[0m"
+
+    print(
+        f"{BOLD_RED}⚠️  DEPRECATION WARNING:{RED} This version of "
+        f"git-find-reviewers has been deprecated."
+    )
+    print(
+        f"It is now being maintained in Khan Academy's OLC repo.{RESET}"
+    )
 
 # How git uses this script: via __main__
 if __name__ == '__main__':
@@ -278,5 +290,7 @@ if __name__ == '__main__':
     parser.set_defaults(revision='HEAD')
 
     args = parser.parse_args()
+
+    print_deprecation_warning()
 
     findreviewers(Git(), **args.__dict__)

--- a/bin/git-recursive-grep
+++ b/bin/git-recursive-grep
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+echo "\n\033[1;31m⚠️  DEPRECATION WARNING:\033[0;31m This version of \
+git-recursive-grep has been deprecated.\033[0m\n"
+
 USAGE=`cat<<EOF
 USAGE: git recursive-grep <pattern>
 

--- a/bin/git-reparent
+++ b/bin/git-reparent
@@ -53,6 +53,9 @@
 
 set -e
 
+echo "\n\033[1;31m⚠️  DEPRECATION WARNING:\033[0;31m This version of \
+git-reparent has been deprecated.\033[0m\n"
+
 if [ -z "$1" ]; then
     echo "USAGE: $0 <branch to set as our upstream>"
     echo "       Call this in the branch you want to reset the upstream."

--- a/bin/git-review-branch
+++ b/bin/git-review-branch
@@ -1,5 +1,9 @@
 #!/bin/sh -e
 
+echo "\n\033[1;31m⚠️  DEPRECATION WARNING:\033[0;31m This version of \
+git-review-branch has been deprecated."
+echo "It is now being maintained in Khan Academy's OLC repo.\033[0m\n"
+
 USAGE=`cat<<EOF
 USAGE: git review-branch <branchname> [parent -- defaults to branch.review-parent-default]
 


### PR DESCRIPTION
## Summary:
For the MFE project, we will want to make sure things like `git deploy-branch` support `main` as the default branch in repos where `main` _is_ the default branch.

To make that happen, we first need to bring the git-workflow repo into OLC (while preserving the git history), so that we can update the scripts and have them show up on folks' computers automatically. (This was a decision made in [this ADR](https://khanacademy.atlassian.net/wiki/spaces/ENG/pages/3283484677/ADR+769+Rethink+our+Standard+Local+Git+Setup+Between+Dotfiles+and+OLC+-+Part+2#Git-Workflow-Repo).)

Then update the versions in this repo to indicate that they're deprecated. (That's this PR!)

The only awkward thing is that this repo is open-source, so the messages might be a little odd to non-ka folks, but not really sure how to elegantly avoid that. 🤷‍♀️ 

Rough plan:
1. Bring git-workflow into OLC while preserving the git history ([PR here](https://github.com/Khan/our-lovely-cli/pull/970))
2. Remove any no-longer-needed-files from OLC ([PR here](https://github.com/Khan/our-lovely-cli/pull/971))
3. Combine the README.md in OLC ([PR here](https://github.com/Khan/our-lovely-cli/pull/972))
4. Update git-workflow repo with deprecation messages  👈 **YOU ARE HERE**
5. Update khan-dotfiles repo to no long install git-workflow ([PR here](https://github.com/Khan/khan-dotfiles/pull/142))
6. Update the scripts to support `main`, etc. ([PR here](https://github.com/Khan/our-lovely-cli/pull/973))

Issue: FEI-6455

## Test plan:
Run the scripts and see the warning. Only works if the OLC versions aren't already on your computer.